### PR TITLE
No docsible vars and yaml parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Docsible is a command-line interface (CLI) written in Python that automates the 
 - CLI-based, easy to integrate into a CI/CD pipeline
 - Provides a templating feature to customize output
 - Supports multiple YAML files within `tasks`, `defaults`, `vars` directory
-- Includes meta-data like author and license from `meta/main.yml`
+- Includes meta-data like author and license from `meta/main.[yml/yaml]`
 - Generates a well-structured table for default and role-specific variables
 - Support for encrypted Ansible Vault variables
 
@@ -62,6 +62,7 @@ Options:
   --playbook TEXT  Path to the playbook file.
   --graph          Generate Mermaid graph for tasks.
   --no-backup      Don't backup the readme before remove.
+  --no-docsible    Don't create .docsible file and do not print relative variable to generated README.md
   --version        Show the module version.
   --help           Show this message and exit.
 ```
@@ -77,10 +78,10 @@ Options:
 
 Docsible fetches information from the following files within the specified Ansible role:
 
-- `defaults/*.yml`: For default variables
-- `vars/*.yml`: For role-specific variables
-- `meta/main.yml`: For role metadata
-- `tasks/*.yml`: For tasks, including special task types and subfolders
+- `defaults/*.yml/yaml`: For default variables
+- `vars/*.yml/yaml`: For role-specific variables
+- `meta/main.yml/yaml`: For role metadata
+- `tasks/*.yml/yaml`: For tasks, including special task types and subfolders
 
 ## Examples
 [Demo1 coffeemaker_midday role](https://github.com/exaluc/docsible/blob/main/examples/README_demo1.md)

--- a/docsible/cli.py
+++ b/docsible/cli.py
@@ -27,14 +27,16 @@ def initialize_docsible(docsible_path, default_data):
     except Exception as e:
         print(f"An error occurred while initializing {docsible_path}: {e}")
 
-
 @click.command()
 @click.option('--role', default='.', help='Path to the Ansible role directory.')
 @click.option('--playbook', default='./tests/test.yml', help='Path to the playbook file.')
 @click.option('--graph', is_flag=True, help='Generate Mermaid graph for tasks.')
 @click.option('--no-backup', is_flag=True, help='Don\'t backup the readme before remove.')
+@click.option('--no-docsible', is_flag=True, help='Don\'t generate .docsible file and do not include it in README.md.')
 @click.version_option(version=get_version(), help="Show the module version.")
-def doc_the_role(role, playbook, graph, no_backup):
+
+
+def doc_the_role(role, playbook, graph, no_backup, no_docsible):
     role_path = os.path.abspath(role)
     if not os.path.exists(role_path) or not os.path.isdir(role_path):
         print(f"Folder {role_path} does not exist.")
@@ -50,39 +52,45 @@ def doc_the_role(role, playbook, graph, no_backup):
         except Exception as e:
             print('playbook import error:', e)
 
-    document_role(role_path, playbook_content, graph, no_backup)
+    document_role(role_path, playbook_content, graph, no_backup, no_docsible)
 
 
-def document_role(role_path, playbook_content, generate_graph, no_backup):
+def document_role(role_path, playbook_content, generate_graph, no_backup, no_docsible):
     role_name = os.path.basename(role_path)
     readme_path = os.path.join(role_path, "README.md")
     meta_path = os.path.join(role_path, "meta", "main.yml")
     timestamp_readme = datetime.now().strftime('%d/%m/%Y')
 
+    # Check if meta/main.yml exist, otherwise try meta/main.yaml
+    if not os.path.exists(meta_path):
+        meta_path = os.path.join(role_path, "meta", "main.yaml")
+
     defaults_data = load_yaml_files_from_dir_custom(
         os.path.join(role_path, "defaults")) or []
     vars_data = load_yaml_files_from_dir_custom(
         os.path.join(role_path, "vars")) or []
-    docsible_path = os.path.join(role_path, ".docsible")
-
-    if os.path.exists(docsible_path):
-        docsible_present = True
+    if no_docsible:
+        docsible_present = False
     else:
-        default_data = {
-            'description': None,
-            'requester': None,
-            'users': None,
-            'dt_dev': None,
-            'dt_prod': None,
-            'dt_update': timestamp_readme,
-            'version': None,
-            'time_saving': None,
-            'category': None,
-            'subCategory': None,
-            'aap_hub': None
-        }
+        docsible_path = os.path.join(role_path, ".docsible")
 
-        if not os.path.exists(docsible_path):
+        if os.path.exists(docsible_path):
+            docsible_present = True
+        else:
+            default_data = {
+                'description': None,
+                'requester': None,
+                'users': None,
+                'dt_dev': None,
+                'dt_prod': None,
+                'dt_update': timestamp_readme,
+                'version': None,
+                'time_saving': None,
+                'category': None,
+                'subCategory': None,
+                'aap_hub': None
+            }
+
             print(f"{docsible_path} not found. Initializing...")
             try:
                 initialize_docsible(docsible_path, default_data)
@@ -107,7 +115,7 @@ def document_role(role_path, playbook_content, generate_graph, no_backup):
     if os.path.exists(tasks_dir) and os.path.isdir(tasks_dir):
         for dirpath, dirnames, filenames in os.walk(tasks_dir):
             for task_file in filenames:
-                if task_file.endswith(".yml"):
+                if task_file.endswith(".yml") or task_file.endswith(".yaml"):
                     file_path = os.path.join(dirpath, task_file)
                     tasks_data = load_yaml_generic(file_path)
                     if tasks_data:

--- a/docsible/markdown_template.py
+++ b/docsible/markdown_template.py
@@ -60,7 +60,7 @@ No vars available.
 
 
 ### Tasks
-{%- if role.tasks|length == 1 and role.tasks[0]['file'] == 'main.yml' %}
+{%- if role.tasks|length == 1 and ( role.tasks[0]['file'] == 'main.yml' or role.tasks[0]['file'] == 'main.yaml' ) %}
 | Name | Module | Condition |
 | ---- | ------ | --------- |
 {%- for task in role.tasks[0]['tasks'] %}

--- a/docsible/utils/yaml.py
+++ b/docsible/utils/yaml.py
@@ -87,13 +87,12 @@ def load_yaml_file_custom(filepath):
         print(f"Error loading {filepath}: {e}")
         return None
 
-
 # Function to load all YAML files from a given directory and include file names
 def load_yaml_files_from_dir_custom(dir_path):
     collected_data = []
     if os.path.exists(dir_path) and os.path.isdir(dir_path):
         for yaml_file in os.listdir(dir_path):
-            if yaml_file.endswith(".yml"):
+            if yaml_file.endswith(".yml") or yaml_file.endswith(".yaml"):
                 file_data = load_yaml_file_custom(os.path.join(dir_path, yaml_file))
                 if file_data:
                     collected_data.append({'file': yaml_file, 'data': file_data})


### PR DESCRIPTION
# Description

With this PR we implement:

1. the parsing og .yaml files, insteadd only the .yml ones
2. the switch --no-docsible. With it a user can avoid the generation of .docsible file in the roles, and the relative reporting to generated README.md

# How Has This Been Tested?

Local testing on our ansible roles

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
