### PR TITLE
Comment management and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ Options:
   --role TEXT      Path to the Ansible role directory.
   --playbook TEXT  Path to the playbook file.
   --graph          Generate Mermaid graph for tasks.
-  --no-backup      Don't backup the readme before remove.
-  --no-docsible    Don't create .docsible file and do not print relative variable to generated README.md
+  --no-backup      Do not backup the readme before remove.
+  --no-docsible    Do not create .docsible file and do not print relative variable to generated README.md.
+  --comments       Read comments from tasks files.
   --version        Show the module version.
   --help           Show this message and exit.
 ```
@@ -73,6 +74,7 @@ Options:
 - `--playbook`: Specifies the path to the Ansible playbook (Optional).
 - `--graph`: Generate mermaid for role and playbook.
 - `--no-backup`: Ignore existent README.md and remove before generate a new one. (Optional).
+- `--comments`: Read comments from tasks files. (Optional).
 
 ## Data Sources
 
@@ -99,6 +101,22 @@ Docsible works with Python 3.x and requires the following libraries:
 ## TODO
 - Clean the code
 - Add more features
+
+## About comments
+
+This tool work whith several type of comments.
+
+### On variables and defaults
+The tool read comments placed before a variable, only if it begin with specific tag:
+
+`# title:` This tag will be used for popiulate the column **Title** of the README.md. It is a short description of the variable
+
+`# required:` This tag will be used for popiulate the column **Required** of the README.md
+
+### On tasks
+
+The tool will read all the line before each `- name:` of the tasks that begin with `#`.
+All comment will be reported to the column **Comments** of the tasks tables.
 
 ## Contributing
 

--- a/docsible/markdown_template.py
+++ b/docsible/markdown_template.py
@@ -1,7 +1,9 @@
 static_template = """{{- role.existing_readme -}}
 
 # Generated Documentation
+
 ## {{ role.name }}
+
 {% if role.meta and role.meta.galaxy_info -%}
 Description: {{ role.meta.galaxy_info.description or 'Not available.' }}
 {% else %}
@@ -25,6 +27,7 @@ Description: Not available.
 
 
 ### Defaults
+
 {% if role.defaults|length > 0 -%}
 **These are static variables with lower priority**
 {%- for defaultfile in role.defaults %}
@@ -43,6 +46,7 @@ No defaults available.
 
 
 ### Vars
+
 {% if role.vars|length > 0 -%}
 **These are variables with higher priority**
 {%- for varsfile in role.vars %}
@@ -60,28 +64,23 @@ No vars available.
 
 
 ### Tasks
-{%- if role.tasks|length == 1 and ( role.tasks[0]['file'] == 'main.yml' or role.tasks[0]['file'] == 'main.yaml' ) %}
-| Name | Module | Has Conditions |
-| ---- | ------ | --------- |
-{%- for task in role.tasks[0]['tasks'] %}
-| {{ task.name }} | {{ task.module }} | {{ 'True' if task.when else 'False' }} |
-{%- endfor %}
-{%- else %}
+
 {% for taskfile in role.tasks %}
 #### File: {{ taskfile.file }}
-| Name | Module | Has Conditions |
-| ---- | ------ | --------- |
+| Name | Module | Has Conditions | Comments |
+| ---- | ------ | --------- |  -------- |
 {%- for task in taskfile.tasks %}
-| {{ task.name }} | {{ task.module }} | {{ 'True' if task.when else 'False' }} |
+| {{ task.name }} | {{ task.module }} | {{ 'True' if task.when else 'False' }} | {{ taskfile['comments'] | selectattr('task_name', 'equalto', task.name) | map(attribute='task_comments') | join }} |
 {%- endfor %}
 {% endfor %}
-{%- endif %}
-
 
 {% if mermaid_code_per_file -%}
 ## Task Flow Graphs
+
 {% for task_file, mermaid_code in mermaid_code_per_file.items() %}
+
 ### Graph for {{ task_file }}
+
 ```mermaid
 {{ mermaid_code }}
 ```
@@ -90,6 +89,7 @@ No vars available.
 
 {% if role.playbook.content -%}
 ## Playbook
+
 ```yml
 {{ role.playbook.content }}
 ```
@@ -106,12 +106,15 @@ No vars available.
 {{ role.meta.galaxy_info.author or 'Unknown Author' }}
 
 #### License
+
 {{ role.meta.galaxy_info.license or 'No license specified.' }}
 
 #### Minimum Ansible Version
+
 {{ role.meta.galaxy_info.min_ansible_version or 'No minimum version specified.' }}
 
 #### Platforms
+
 {% if role.meta.galaxy_info.platforms -%}
 {% for platform in role.meta.galaxy_info.platforms -%}
 - **{{ platform.name }}**: {{ platform.versions }}

--- a/docsible/markdown_template.py
+++ b/docsible/markdown_template.py
@@ -61,7 +61,7 @@ No vars available.
 
 ### Tasks
 {%- if role.tasks|length == 1 and ( role.tasks[0]['file'] == 'main.yml' or role.tasks[0]['file'] == 'main.yaml' ) %}
-| Name | Module | Condition |
+| Name | Module | Has Conditions |
 | ---- | ------ | --------- |
 {%- for task in role.tasks[0]['tasks'] %}
 | {{ task.name }} | {{ task.module }} | {{ 'True' if task.when else 'False' }} |
@@ -69,7 +69,7 @@ No vars available.
 {%- else %}
 {% for taskfile in role.tasks %}
 #### File: {{ taskfile.file }}
-| Name | Module | Condition |
+| Name | Module | Has Conditions |
 | ---- | ------ | --------- |
 {%- for task in taskfile.tasks %}
 | {{ task.name }} | {{ task.module }} | {{ 'True' if task.when else 'False' }} |

--- a/docsible/utils/yaml.py
+++ b/docsible/utils/yaml.py
@@ -109,3 +109,27 @@ def load_yaml_files_from_dir_custom(dir_path):
                 if file_data:
                     collected_data.append({'file': yaml_file, 'data': file_data})
     return collected_data
+
+def get_task_commensts(filepath):
+    # read task file
+    with open(filepath, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+
+    task_comments = []
+    task_comment = {}
+    comment_line = ""
+    for line in lines:
+        stripped_line = line.strip()
+        # the line is a comment, ad it to buffer comment_line
+        if stripped_line.startswith("#"):
+            comment_line =  comment_line+ stripped_line.split("#", 1)[1].strip()
+        #if the line start with "- name:" assign to it the previous comment
+        elif stripped_line.startswith("- name:"):
+            if comment_line:
+                task_name =  stripped_line.replace("- name:", "").split("#")[0].strip()
+                task_comment = { "task_name": task_name, "task_comments": comment_line }
+                task_comments.append(task_comment)
+                comment_line = ""
+        else:
+            comment_line = ""
+    return task_comments

--- a/docsible/utils/yaml.py
+++ b/docsible/utils/yaml.py
@@ -52,9 +52,14 @@ def load_yaml_file_custom(filepath):
                         current_list_items = []
 
                     # Added dis to avoid inline comments to be part of the value
-                    cleand_line = stripped_line.split("#")[0]
+                    stripped_line = stripped_line.split("#")[0].rstrip()
+                    # If the inline comment is on an array variable:
+                    if stripped_line.endswith(":"):
+                        current_list_var = stripped_line[:-1].strip()
+                        current_list_items = []
+                        continue
 
-                    parts = cleand_line.split(":", 1)
+                    parts = stripped_line.split(":", 1)
                     var_name = parts[0].strip()
                     value = parts[1].strip()
 
@@ -75,7 +80,7 @@ def load_yaml_file_custom(filepath):
                 current_list_items = []
 
             elif current_list_var:
-                current_list_items.append(stripped_line)
+                current_list_items.append(stripped_line.split("#")[0])
 
             else:
                 current_title = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "docsible"
-version = "0.5.01"
+version = "0.5.5"
 description = "Document generator for ansible role"
 authors = ["Lucian BLETAN <neuraluc@gmail.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='docsible',
-    version='0.5.01',
+    version='0.5.5',
     packages=find_packages(),
     include_package_data=True,
     author='Lucian BLETAN',


### PR DESCRIPTION
# Description

With this PR we had:
- Fixed some minor issue on inline comments in vars and defaults (see line 55 of yamnl.py) that cause value disapper on lists
- Implemented the `--comments` feature
- Added comment management description in project's README.md

The comment feature, as described in readme, read all the line before each `- name:` of the tasks that begin with `#`.
All comment will be reported to the column **Comments** of the tasks tables on the generated README.md

# How Has This Been Tested?

We have tested all in our production ansible env.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
