### PR TITLE
Fix: Escape pipe characters in variable values for Markdown tables

### DIFF
--- a/docsible/cli.py
+++ b/docsible/cli.py
@@ -11,7 +11,7 @@ from docsible.utils.yaml import load_yaml_generic, load_yaml_files_from_dir_cust
 from docsible.utils.special_tasks_keys import process_special_task_keys
 
 def get_version():
-    return "0.6.1"
+    return "0.6.2"
 
 def manage_docsible_file_keys(docsible_path):
     default_data = {

--- a/docsible/markdown_template.py
+++ b/docsible/markdown_template.py
@@ -50,7 +50,7 @@ Description: Not available.
 |--------------|--------------|-------------|{% if ns.details_required %}-------------|{% endif %}{% if ns.details_title %}-------------|{% endif %}
 {%- for key, details in defaultfile.data.items() %}
 {%- set var_type = details.value.__class__.__name__ %}
-| [{{ key }}](defaults/{{ defaultfile.file }}#L{{details.line}})   | {{ var_type }}   | {{ details.value }}  | {% if ns.details_required %} {{ details.required }}  |{% endif %} {% if ns.details_title %} {{ details.title }} |{% endif %}
+| [{{ key }}](defaults/{{ defaultfile.file }}#L{{details.line}})   | {{ var_type }}   | `{{ details.value | replace('|', '\|') }}`  | {% if ns.details_required %} {{ details.required }}  |{% endif %} {% if ns.details_title %} {{ details.title | replace('|', '\|') }} |{% endif %}
 {%- endfor %}
 {%- endfor %}
 {%- else %}
@@ -69,7 +69,7 @@ Description: Not available.
 |--------------|--------------|-------------|{% if ns.details_required %}-------------|{% endif %}{% if ns.details_title %}-------------|{% endif %}
 {%- for key, details in varsfile.data.items() %}
 {%- set var_type = details.value.__class__.__name__ %}
-| [{{ key }}](vars/{{ varsfile.file }}#L{{details.line}})    | {{ var_type }}   | {{ details.value }}  |{% if ns.details_required %} {{ details.required }} |{% endif %}{% if ns.details_title %} {{ details.title }} |{% endif %}
+| [{{ key }}](vars/{{ varsfile.file }}#L{{details.line}})    | {{ var_type }}   | `{{ details.value | replace('|', '\|') }}`  |{% if ns.details_required %} {{ details.required }} |{% endif %}{% if ns.details_title %} {{ details.title | replace('|', '\|') }} |{% endif %}
 {%- endfor %}
 {%- endfor %}
 {%- else %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "docsible"
-version = "0.6.1"
+version = "0.6.2"
 description = "Document generator for ansible role/collection"
 authors = ["Lucian BLETAN <neuraluc@gmail.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='docsible',
-    version='0.6.1',
+    version='0.6.2',
     packages=find_packages(),
     include_package_data=True,
     author='Lucian BLETAN',


### PR DESCRIPTION
- Updated templates to replace pipe characters (`|`) with escaped versions (`\|`) in variable values and titles.
- Ensures Markdown tables are not broken by pipe characters in Jinja2 expressions.
- Added logic to determine if the Title and Required columns should be included based on variable metadata.