### PR TITLE
Load argument_specs.yml

### DIFF
--- a/docsible/cli.py
+++ b/docsible/cli.py
@@ -177,6 +177,7 @@ def document_role(role_path, playbook_content, generate_graph, no_backup, no_doc
     readme_path = os.path.join(role_path, output)
     meta_path = os.path.join(role_path, "meta", "main.yml")
     docsible_path = os.path.join(role_path, ".docsible")
+    args_path = os.path.join(role_path, "meta", "argument_specs.yml")
     if not no_docsible:
         manage_docsible_file_keys(docsible_path)
 
@@ -189,6 +190,10 @@ def document_role(role_path, playbook_content, generate_graph, no_backup, no_doc
     vars_data = load_yaml_files_from_dir_custom(
         os.path.join(role_path, "vars")) or []
 
+    # Load meta/argument_specs.yml when available
+    args = {}
+    if os.path.exists(args_path):
+        args = load_yaml_generic(args_path).get('argument_specs') if load_yaml_generic(args_path) else {}
     role_info = {
         "name": role_name,
         "defaults": defaults_data,
@@ -198,7 +203,8 @@ def document_role(role_path, playbook_content, generate_graph, no_backup, no_doc
         "playbook": {"content": playbook_content, "graph": 
                         generate_mermaid_playbook(yaml.safe_load(playbook_content)) if playbook_content else None},
         "docsible": load_yaml_generic(docsible_path) if not no_docsible else None,
-        "belongs_to_collection": belongs_to_collection
+        "belongs_to_collection": belongs_to_collection,
+        "args": args
     }
 
     tasks_dir = os.path.join(role_path, "tasks")


### PR DESCRIPTION
Read arbument_specs.yml when available and make them available as args to the role.

# Description

Read from `meta/argument_specs.yml` and make it available as `args` under the `role` info.

Fixes #24 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
With a custom template I was able to produce a table with the information from `argument_specs.yml`

```
{% if role.args -%}
## Inputs

| Var  | Type  | Required | Default  | Description
| ---- | ----- | -------- | -------- | -----------
{% for key in role.args.keys() -%}
{% for input_var, details in role.args[key].options.items() -%}
| {{ input_var }} | {{ details.type }} | {{ details.required }} | {{ details.default | default('\<undefined\>') }} | {{ " ".join(details.description) }}
{% endfor -%}
{% endfor -%}
{% endif -%}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
