### PR TITLE
docker: add basic Dockerfile for containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:latest
+
+WORKDIR /usr/local/
+ENV PATH="/usr/local/docsible/bin:$PATH"
+
+COPY . . 
+
+RUN apk update && \
+    apk add python3 && \
+    apk add py3-pip && \
+    python3 -m venv ./docsible && \
+    . ./docsible/bin/activate && \
+    pip install docsible
+
+ENTRYPOINT ["docsible"]


### PR DESCRIPTION
# Description

This commit introduces a basic Dockerfile allowing to build docker images from the project since I couldn't find any. I believe not using containers is today an obstacle for democratizing a project, since not everyone wants to install a virtual env whether locally or within a CI.

Fixes - none opened

# How Has This Been Tested?

Yes, generated the image locally, build a script & Makefile for my project in order to validate it.

- clone the branch
- `docker build . -t docsible:0.8.0 # or whatever tag you want`
- `docker images | grep docsible # image is around 90MB`
- `docker run docsible:0.8.0 --help # display the help of docsible`

If you want to test locally against an ansible project you can:
- `docker run --user $(id -u):$(id -g) -v ${PWD}/roles:/tmp/ -it docsible:0.8.0 -r /tmp/roleXYZ --no-backup`

It should generate the files locally according to the options you've provided.

# Checklist:

- N.A. My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- N.A. I have added tests that prove my fix is effective or that my feature works
- N.A. New and existing unit tests pass locally with my changes
- N.A. Any dependent changes have been merged and published in downstream modules

Regarding the documentation I did not update it, because I believe some elements are missing which are out reach. The Dockerfile could be used as a base to regularly build images which would then be published to dockerhub or similar. Without this, I don't think it would make too much sense to add documentation for a local build.

If you think otherwise I can do so, but I believe an automated dockerhub release would be preferred - but those depends on your CI / github workflow which I can't do.